### PR TITLE
docs: translate README, docs, and copilot-instructions to English

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,19 +1,19 @@
 # Copilot Code Review Instructions
 
-## プロジェクト概要
+## Project Overview
 
-Street Fighter 6 のフレームデータ閲覧・確定反撃検索アプリ（React Native / Expo）。
+A Street Fighter 6 frame data viewer and punish finder app built with React Native / Expo.
 
-## レビュー観点
+## Review Focus
 
-- TypeScript の strict mode に準拠しているか
-- React Native と Web の両方で動作するコードか（プラットフォーム固有の API を使っていないか）
-- i18n: ハードコードされた日本語/英語文字列がないか（UI テキストは `i18n/` の翻訳キーを使う）
-- フレームデータの型（`Move`, `CharacterFrameData`）が正しく使われているか
-- `@/` パスエイリアスが一貫して使われているか
+- Ensure compliance with TypeScript strict mode
+- Verify code works on both React Native and Web (no platform-specific APIs without abstractions)
+- i18n: No hardcoded UI strings — use translation keys from `i18n/`
+- Correct usage of frame data types (`Move`, `CharacterFrameData`)
+- Consistent use of `@/` path aliases
 
-## コーディング規約
+## Coding Conventions
 
-- パッケージマネージャーは pnpm
-- コミットメッセージは Conventional Commits 形式
-- Prettier + ESLint でフォーマット・リント済みであること
+- Package manager: pnpm
+- Commit messages: Conventional Commits format
+- Code must pass Prettier formatting and ESLint checks

--- a/README.md
+++ b/README.md
@@ -2,53 +2,53 @@
 
 [![CI](https://github.com/YuiSakamoto/sf6-frame-app/actions/workflows/ci.yml/badge.svg)](https://github.com/YuiSakamoto/sf6-frame-app/actions/workflows/ci.yml)
 
-Street Fighter 6 のフレームデータ閲覧 & 確定反撃検索アプリ。
+A frame data viewer and punish finder app for Street Fighter 6.
 
-## 機能
+## Features
 
-- **フレームデータ閲覧**: 全28キャラクターの技データをカテゴリ別に表示
-- **確定反撃検索**: 相手技をガードした際の確反候補を即座に検索
-- **グローバル検索**: 技名・コマンドで全キャラ横断検索
-- **オフライン対応**: バンドル済みデータで起動即使用可
-- **多言語対応**: 14言語の UI
+- **Frame Data Viewer**: Browse move data for all 28 characters by category
+- **Punish Finder**: Instantly find punish options after blocking an opponent's move
+- **Global Search**: Search across all characters by move name or command input
+- **Offline Support**: Bundled data works immediately, with background sync for updates
+- **Multilingual**: UI available in 14 languages
 
-## セットアップ
+## Setup
 
 ```bash
 pnpm install
 ```
 
-## 開発
+## Development
 
 ```bash
 pnpm web             # Web
-pnpm ios             # iOS シミュレーター
-pnpm android         # Android エミュレーター
+pnpm ios             # iOS Simulator
+pnpm android         # Android Emulator
 ```
 
-## テスト & 品質チェック
+## Testing & Quality
 
 ```bash
-pnpm test            # ユニットテスト実行
-pnpm test:watch      # ウォッチモード
-pnpm test:coverage   # カバレッジレポート付き
-pnpm typecheck       # TypeScript 型チェック
+pnpm test            # Run unit tests
+pnpm test:watch      # Watch mode
+pnpm test:coverage   # With coverage report
+pnpm typecheck       # TypeScript type check
 pnpm lint            # ESLint
-pnpm format:check    # Prettier フォーマットチェック
+pnpm format:check    # Prettier format check
 ```
 
-## ドキュメント
+## Documentation
 
-詳細なドキュメントは [docs/](docs/) を参照してください。
+See [docs/](docs/) for detailed documentation.
 
-- [アーキテクチャ](docs/architecture.md)
+- [Architecture](docs/architecture.md)
 - [CI/CD](docs/ci.md)
-- [スクレイパー](docs/scraper.md)
+- [Scraper](docs/scraper.md)
 
-## 技術スタック
+## Tech Stack
 
-| カテゴリ | 技術 |
-|---------|------|
+| Category | Technology |
+|----------|-----------|
 | Framework | Expo SDK 55 / React Native |
 | Routing | Expo Router (file-based) |
 | State | Zustand |
@@ -57,6 +57,6 @@ pnpm format:check    # Prettier フォーマットチェック
 | CI | GitHub Actions |
 | Package Manager | pnpm |
 
-## データソース
+## Data Source
 
-- [Capcom SF6 公式サイト](https://www.streetfighter.com/6/ja-jp/)
+- [Capcom SF6 Official Site](https://www.streetfighter.com/6/ja-jp/)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,51 +1,51 @@
-# アーキテクチャ
+# Architecture
 
-## プロジェクト構造
+## Project Structure
 
 ```
 src/
-├── app/                  # Expo Router ページ（ファイルベースルーティング）
-│   ├── (tabs)/           # タブ: ホーム / 確反検索 / 検索
-│   └── character/[slug]  # キャラクター詳細
-├── components/           # UI コンポーネント
-├── hooks/                # カスタムフック
-├── stores/               # Zustand ストア
-├── services/             # データ取得・キャッシュ
-├── i18n/                 # 翻訳ファイル (14言語)
-├── types/                # TypeScript 型定義
-├── utils/                # ユーティリティ関数
-└── theme/                # SF6 テーマカラー
+├── app/                  # Expo Router pages (file-based routing)
+│   ├── (tabs)/           # Tabs: Home / Punish Finder / Search
+│   └── character/[slug]  # Character detail
+├── components/           # UI components
+├── hooks/                # Custom hooks
+├── stores/               # Zustand stores
+├── services/             # Data fetching & caching
+├── i18n/                 # Translation files (14 languages)
+├── types/                # TypeScript type definitions
+├── utils/                # Utility functions
+└── theme/                # SF6 theme colors
 data/
-├── characters.json       # キャラクター一覧
-├── version.json          # データバージョン
-└── frames/               # キャラ別フレームデータ JSON (28キャラ)
-scripts/scraper/          # Playwright スクレイパー
+├── characters.json       # Character list
+├── version.json          # Data version
+└── frames/               # Per-character frame data JSON (28 characters)
+scripts/scraper/          # Playwright scraper
 ```
 
-## 技術スタック
+## Tech Stack
 
-- **フレームワーク**: React Native (Expo SDK 55) + expo-router
-- **スタイリング**: NativeWind (TailwindCSS)
-- **状態管理**: Zustand
-- **ストレージ**: AsyncStorage + メモリキャッシュ (native) / localStorage (web)
-- **多言語対応**: i18next + react-i18next + expo-localization
-- **言語**: TypeScript (strict mode)
+- **Framework**: React Native (Expo SDK 55) + expo-router
+- **Styling**: NativeWind (TailwindCSS)
+- **State Management**: Zustand
+- **Storage**: AsyncStorage + in-memory cache (native) / localStorage (web)
+- **i18n**: i18next + react-i18next + expo-localization
+- **Language**: TypeScript (strict mode)
 
-## パスエイリアス
+## Path Aliases
 
-- `@/*` → `src/*`（tsconfig.json で設定）
+- `@/*` → `src/*` (configured in tsconfig.json)
 
-## 確定反撃ロジック
+## Punish Logic
 
 ```
-確反成立条件: |相手技のガード時フレーム| >= 自キャラの技の発生フレーム
+Punish condition: |opponent's on-block frame| >= your move's startup frames
 
-例: 相手の技がガード時 -8F → 自キャラの発生 8F 以下の技が確定反撃
+Example: Opponent's move is -8F on block → Any move with 8F or less startup is a punish
 ```
 
-## データフロー
+## Data Flow
 
-1. アプリ起動時に `data/frames/` のバンドル済み JSON を読み込み
-2. Zustand ストアに格納
-3. バックグラウンドで GitHub Raw URL から最新データをチェック
-4. 更新があればダウンロードしてキャッシュを更新
+1. On app launch, load bundled JSON from `data/frames/`
+2. Store in Zustand store
+3. Check for updates in background via GitHub Raw URL
+4. Download and update cache if newer data is available

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,48 +1,48 @@
 # CI/CD
 
-GitHub Actions による自動化パイプライン。
+Automated pipeline powered by GitHub Actions.
 
-## ワークフロー一覧
+## Workflows
 
 ### CI (`ci.yml`)
 
-PR と main push で実行。3 ジョブ構成:
+Runs on PRs and main push. 3-job pipeline:
 
-| ジョブ | 内容 |
-|--------|------|
-| `lint-typecheck` | TypeScript 型チェック → ESLint → Prettier フォーマットチェック |
-| `test` | Vitest ユニットテスト + カバレッジ |
-| `build-web` | Expo Web ビルド検証 (`lint-typecheck` と `test` の両方完了後) |
+| Job | Description |
+|-----|-------------|
+| `lint-typecheck` | TypeScript type check → ESLint → Prettier format check |
+| `test` | Vitest unit tests + coverage |
+| `build-web` | Expo Web build verification (runs after `lint-typecheck` and `test`) |
 
 ### Copilot Code Review (Ruleset)
 
-PR 作成・更新時に GitHub Copilot が自動でコードレビュー。
-Rulesets で有効化済み。カスタム指示は `.github/copilot-instructions.md` に定義。
+Automatic code review by GitHub Copilot on PR creation and updates.
+Enabled via Rulesets. Custom instructions defined in `.github/copilot-instructions.md`.
 
 ### CodeQL (Default Setup)
 
-GitHub 公式の静的解析セキュリティテスト (SAST)。
-Default Setup で有効化済み（ワークフローファイル不要）。
+GitHub's official SAST (Static Application Security Testing).
+Enabled via Default Setup (no workflow file needed).
 
 ### OSV-Scanner (`osv-scanner.yml`)
 
-Google 製の依存パッケージ脆弱性スキャナー。
-OSV データベースを使い、既知の脆弱性を検出。
+Google's dependency vulnerability scanner.
+Detects known vulnerabilities using the OSV database.
 
-## テストコマンド
+## Test Commands
 
 ```bash
-pnpm test            # 全テスト実行
-pnpm test:watch      # ウォッチモード
-pnpm test:coverage   # カバレッジレポート
-pnpm test:ci         # CI 用 (github-actions reporter)
+pnpm test            # Run all tests
+pnpm test:watch      # Watch mode
+pnpm test:coverage   # With coverage report
+pnpm test:ci         # CI mode (github-actions reporter)
 ```
 
-## 依存パッケージ管理
+## Dependency Management
 
-[Renovate](https://github.com/renovatebot/renovate) で自動更新。
+Automated updates via [Renovate](https://github.com/renovatebot/renovate).
 
-- devDependencies の minor/patch は自動マージ
-- Expo SDK / React Native のメジャーアップデートは手動対応
-- GitHub Actions のアップデートはグルーピング
-- 毎週月曜朝にチェック
+- Auto-merge minor/patch updates for devDependencies
+- Major updates for Expo SDK / React Native require manual review
+- GitHub Actions updates are grouped together
+- Runs weekly on Monday mornings

--- a/docs/scraper.md
+++ b/docs/scraper.md
@@ -1,37 +1,37 @@
-# スクレイパー
+# Scraper
 
-Capcom 公式サイトからフレームデータを取得するスクリプト。
+Scripts to fetch frame data from the official Capcom website.
 
-## セットアップ
+## Setup
 
 ```bash
-# Playwright ブラウザをインストール（初回のみ）
+# Install Playwright browser (first time only)
 pnpm exec playwright install chromium
 ```
 
-## 使い方
+## Usage
 
 ```bash
-# 全キャラスクレイピング
+# Scrape all characters
 pnpm exec tsx scripts/scraper/src/index.ts
 
-# 特定キャラのみ
+# Scrape a specific character
 pnpm exec tsx scripts/scraper/src/index.ts --character ryu
 ```
 
-取得したデータは `data/frames/<character>.json` に保存されます。
+Output is saved to `data/frames/<character>.json`.
 
-## データ構造
+## Data Structure
 
-各キャラクターの JSON ファイルには以下が含まれます:
+Each character JSON file contains:
 
-- `slug` - キャラクター識別子
-- `name` / `nameJa` - 英語名 / 日本語名
-- `version` - ゲームバージョン
-- `moves[]` - 技リスト
-  - `name` / `nameJa` - 技名
-  - `input` - コマンド入力
-  - `startup` / `active` / `recovery` - フレームデータ
-  - `onBlock` / `onHit` - ガード時 / ヒット時フレーム
-  - `damage` - ダメージ
-  - `category` - カテゴリ (normal, special, super, unique, throw, common)
+- `slug` - Character identifier
+- `name` / `nameJa` - English / Japanese name
+- `version` - Game version
+- `moves[]` - Move list
+  - `name` / `nameJa` - Move name
+  - `input` - Command input
+  - `startup` / `active` / `recovery` - Frame data
+  - `onBlock` / `onHit` - On-block / on-hit frames
+  - `damage` - Damage value
+  - `category` - Category (normal, special, super, unique, throw, common)


### PR DESCRIPTION
## Summary
- Translate all documentation from Japanese to English
  - README.md
  - docs/architecture.md
  - docs/ci.md
  - docs/scraper.md
  - .github/copilot-instructions.md

## Note
This was part of the previous PR branch but was committed after the merge. Cherry-picked to bring it to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)