### PR TITLE
ci: skip CI workflows for markdown-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,12 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -3,8 +3,12 @@ name: OSV-Scanner
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
   schedule:
     - cron: "0 0 * * 1"
 


### PR DESCRIPTION
## Summary
- Add `paths-ignore: **/*.md` to `ci.yml` and `osv-scanner.yml`
- Documentation-only changes no longer trigger lint, test, build, or vulnerability scan jobs

## Note
If a future PR contains only `.md` changes and Required Status Checks block the merge, the Rulesets may need to be updated to allow skipped checks to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)