### PR TITLE
refactor: Stepper コンポーネントの StyleSheet.create 移行

### DIFF
--- a/src/components/ui/Stepper.tsx
+++ b/src/components/ui/Stepper.tsx
@@ -1,4 +1,4 @@
-import { Text, View } from "react-native";
+import { StyleSheet, Text, View } from "react-native";
 import { colors } from "@/theme/colors";
 
 interface StepperProps {
@@ -8,63 +8,36 @@ interface StepperProps {
 
 export function Stepper({ steps, currentStep }: StepperProps) {
   return (
-    <View
-      style={{
-        flexDirection: "row",
-        alignItems: "center",
-        justifyContent: "center",
-        paddingVertical: 10,
-        paddingHorizontal: 16,
-        gap: 4,
-      }}
-    >
+    <View style={styles.container}>
       {steps.map((label, index) => {
         const isActive = index === currentStep;
         const isDone = index < currentStep;
 
         return (
-          <View
-            key={index}
-            style={{ flexDirection: "row", alignItems: "center" }}
-          >
+          <View key={index} style={styles.step}>
             {/* ステップ番号 */}
             <View
-              style={{
-                width: 20,
-                height: 20,
-                borderRadius: 10,
-                backgroundColor: isActive
-                  ? colors.accent
-                  : isDone
-                    ? colors.accent
-                    : colors.surfaceLight,
-                alignItems: "center",
-                justifyContent: "center",
-              }}
+              style={[
+                styles.circle,
+                (isActive || isDone) && styles.circleActive,
+              ]}
             >
               <Text
-                style={{
-                  fontSize: 10,
-                  fontWeight: "700",
-                  color:
-                    isActive || isDone ? colors.background : colors.textMuted,
-                }}
+                style={[
+                  styles.circleText,
+                  (isActive || isDone) && styles.circleTextActive,
+                ]}
               >
                 {isDone ? "✓" : index + 1}
               </Text>
             </View>
             {/* ラベル */}
             <Text
-              style={{
-                fontSize: 10,
-                fontWeight: isActive ? "700" : "400",
-                color: isActive
-                  ? colors.accent
-                  : isDone
-                    ? colors.text
-                    : colors.textMuted,
-                marginLeft: 4,
-              }}
+              style={[
+                styles.label,
+                isActive && styles.labelActive,
+                isDone && styles.labelDone,
+              ]}
               numberOfLines={1}
             >
               {label}
@@ -72,12 +45,7 @@ export function Stepper({ steps, currentStep }: StepperProps) {
             {/* コネクタライン */}
             {index < steps.length - 1 && (
               <View
-                style={{
-                  width: 20,
-                  height: 1,
-                  backgroundColor: isDone ? colors.accent : colors.border,
-                  marginLeft: 4,
-                }}
+                style={[styles.connector, isDone && styles.connectorDone]}
               />
             )}
           </View>
@@ -86,3 +54,59 @@ export function Stepper({ steps, currentStep }: StepperProps) {
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+    gap: 4,
+  },
+  step: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  circle: {
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+    backgroundColor: colors.surfaceLight,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  circleActive: {
+    backgroundColor: colors.accent,
+  },
+  circleText: {
+    fontSize: 10,
+    fontWeight: "700",
+    color: colors.textMuted,
+  },
+  circleTextActive: {
+    color: colors.background,
+  },
+  label: {
+    fontSize: 10,
+    fontWeight: "400",
+    color: colors.textMuted,
+    marginLeft: 4,
+  },
+  labelActive: {
+    fontWeight: "700",
+    color: colors.accent,
+  },
+  labelDone: {
+    color: colors.text,
+  },
+  connector: {
+    width: 20,
+    height: 1,
+    backgroundColor: colors.border,
+    marginLeft: 4,
+  },
+  connectorDone: {
+    backgroundColor: colors.accent,
+  },
+});


### PR DESCRIPTION
## Summary
- Stepper コンポーネントのインラインスタイルを `StyleSheet.create` に移行
- 条件付きスタイルを配列形式（`[styles.base, condition && styles.active]`）で統一
- デザインリファクタリング Phase 1 の残作業

## Test plan
- [x] `pnpm typecheck` GREEN
- [x] `pnpm lint` GREEN
- [x] `pnpm test` GREEN (76 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)