### PR TITLE
refactor: 残りコンポーネントの StyleSheet.create 移行

### DIFF
--- a/src/components/character/CharacterGrid.tsx
+++ b/src/components/character/CharacterGrid.tsx
@@ -1,4 +1,4 @@
-import { FlatList, View } from "react-native";
+import { FlatList, StyleSheet, View } from "react-native";
 import type { Character } from "@/types/character";
 import { CharacterCard } from "./CharacterCard";
 
@@ -18,10 +18,10 @@ export function CharacterGrid({
       data={characters}
       keyExtractor={(item) => item.slug}
       numColumns={4}
-      contentContainerStyle={{ padding: 16, gap: 8 }}
-      columnWrapperStyle={{ gap: 8 }}
+      contentContainerStyle={styles.content}
+      columnWrapperStyle={styles.column}
       renderItem={({ item }) => (
-        <View style={{ flex: 1, maxWidth: "25%" }}>
+        <View style={styles.item}>
           <CharacterCard
             character={item}
             onPress={onSelect}
@@ -32,3 +32,17 @@ export function CharacterGrid({
     />
   );
 }
+
+const styles = StyleSheet.create({
+  content: {
+    padding: 16,
+    gap: 8,
+  },
+  column: {
+    gap: 8,
+  },
+  item: {
+    flex: 1,
+    maxWidth: "25%",
+  },
+});

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -1,4 +1,4 @@
-import { Text, View } from "react-native";
+import { StyleSheet, Text, View } from "react-native";
 import { colors } from "@/theme/colors";
 
 interface BadgeProps {
@@ -13,15 +13,20 @@ export function Badge({
   bgColor = colors.surfaceLight,
 }: BadgeProps) {
   return (
-    <View
-      style={{
-        backgroundColor: bgColor,
-        paddingHorizontal: 8,
-        paddingVertical: 2,
-        borderRadius: 4,
-      }}
-    >
-      <Text style={{ color, fontSize: 11, fontWeight: "600" }}>{label}</Text>
+    <View style={[styles.container, { backgroundColor: bgColor }]}>
+      <Text style={[styles.label, { color }]}>{label}</Text>
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 4,
+  },
+  label: {
+    fontSize: 11,
+    fontWeight: "600",
+  },
+});

--- a/src/components/ui/FilterChip.tsx
+++ b/src/components/ui/FilterChip.tsx
@@ -1,4 +1,4 @@
-import { Pressable, Text } from "react-native";
+import { Pressable, StyleSheet, Text } from "react-native";
 import { colors } from "@/theme/colors";
 
 interface FilterChipProps {
@@ -11,25 +11,44 @@ export function FilterChip({ label, selected, onPress }: FilterChipProps) {
   return (
     <Pressable
       onPress={onPress}
-      style={{
-        paddingHorizontal: 12,
-        paddingVertical: 6,
-        borderRadius: 16,
-        backgroundColor: selected ? colors.accent : colors.surface,
-        borderWidth: 1,
-        borderColor: selected ? colors.accent : colors.border,
-        marginRight: 8,
-      }}
+      style={[
+        styles.chip,
+        selected && styles.chipSelected,
+      ]}
     >
       <Text
-        style={{
-          color: selected ? colors.background : colors.text,
-          fontSize: 12,
-          fontWeight: selected ? "700" : "400",
-        }}
+        style={[
+          styles.label,
+          selected && styles.labelSelected,
+        ]}
       >
         {label}
       </Text>
     </Pressable>
   );
 }
+
+const styles = StyleSheet.create({
+  chip: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 16,
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: colors.border,
+    marginRight: 8,
+  },
+  chipSelected: {
+    backgroundColor: colors.accent,
+    borderColor: colors.accent,
+  },
+  label: {
+    color: colors.text,
+    fontSize: 12,
+    fontWeight: "400",
+  },
+  labelSelected: {
+    color: colors.background,
+    fontWeight: "700",
+  },
+});

--- a/src/components/ui/FilterChip.tsx
+++ b/src/components/ui/FilterChip.tsx
@@ -11,17 +11,9 @@ export function FilterChip({ label, selected, onPress }: FilterChipProps) {
   return (
     <Pressable
       onPress={onPress}
-      style={[
-        styles.chip,
-        selected && styles.chipSelected,
-      ]}
+      style={[styles.chip, selected && styles.chipSelected]}
     >
-      <Text
-        style={[
-          styles.label,
-          selected && styles.labelSelected,
-        ]}
-      >
+      <Text style={[styles.label, selected && styles.labelSelected]}>
         {label}
       </Text>
     </Pressable>

--- a/src/components/ui/SearchBar.tsx
+++ b/src/components/ui/SearchBar.tsx
@@ -1,4 +1,4 @@
-import { TextInput, View } from "react-native";
+import { StyleSheet, TextInput, View } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { colors } from "@/theme/colors";
 import { useTranslation } from "react-i18next";
@@ -17,28 +17,10 @@ export function SearchBar({
   const { t } = useTranslation();
 
   return (
-    <View
-      style={{
-        flexDirection: "row",
-        alignItems: "center",
-        backgroundColor: colors.surface,
-        borderRadius: 8,
-        paddingHorizontal: 12,
-        marginHorizontal: 16,
-        marginVertical: 8,
-        height: 40,
-        borderWidth: 1,
-        borderColor: colors.border,
-      }}
-    >
+    <View style={styles.container}>
       <Ionicons name="search" size={18} color={colors.textSecondary} />
       <TextInput
-        style={{
-          flex: 1,
-          marginLeft: 8,
-          color: colors.text,
-          fontSize: 14,
-        }}
+        style={styles.input}
         value={value}
         onChangeText={onChangeText}
         placeholder={placeholder ?? t("common.search")}
@@ -49,3 +31,24 @@ export function SearchBar({
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: colors.surface,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    marginHorizontal: 16,
+    marginVertical: 8,
+    height: 40,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  input: {
+    flex: 1,
+    marginLeft: 8,
+    color: colors.text,
+    fontSize: 14,
+  },
+});


### PR DESCRIPTION
## Summary
- Badge, SearchBar, CharacterGrid のインラインスタイルを `StyleSheet.create` に移行
- これでほぼ全コンポーネントが統一されたスタイル管理パターンに

## Test plan
- [x] `pnpm typecheck` GREEN
- [x] `pnpm lint` GREEN
- [x] `pnpm test` GREEN (76 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)