### PR TITLE
fix(ui): モバイル横はみ出し解消 & サイト名/データバージョンを常時表示

### DIFF
--- a/src/app/(tabs)/_layout.tsx
+++ b/src/app/(tabs)/_layout.tsx
@@ -2,6 +2,7 @@ import { Tabs } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import { colors } from "@/theme/colors";
 import { useTranslation } from "react-i18next";
+import { AppHeader } from "@/components/ui/AppHeader";
 
 export default function TabLayout() {
   const { t } = useTranslation();
@@ -9,9 +10,13 @@ export default function TabLayout() {
   return (
     <Tabs
       screenOptions={{
-        headerStyle: { backgroundColor: colors.background },
-        headerTintColor: colors.text,
-        headerTitleStyle: { fontWeight: "700" },
+        header: ({ options }) => (
+          <AppHeader
+            sectionTitle={
+              typeof options.title === "string" ? options.title : undefined
+            }
+          />
+        ),
         tabBarStyle: {
           backgroundColor: colors.background,
           borderTopColor: colors.border,

--- a/src/app/(tabs)/settings.tsx
+++ b/src/app/(tabs)/settings.tsx
@@ -109,15 +109,6 @@ export default function SettingsScreen() {
           <Text style={styles.linkLabel}>{t("support.buymeacoffee")}</Text>
           <Text style={styles.arrow}>›</Text>
         </Pressable>
-        <Pressable
-          style={styles.linkRow}
-          onPress={() =>
-            Linking.openURL("https://github.com/YuiSakamoto/sf6-frame-app")
-          }
-        >
-          <Text style={styles.linkLabel}>{t("support.githubRepo")}</Text>
-          <Text style={styles.arrow}>›</Text>
-        </Pressable>
 
         {/* クレジット・プライバシーポリシー */}
         <SectionHeader label={t("credits.title")} />

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -9,6 +9,7 @@ import { useDataSync } from "@/hooks/useDataSync";
 import { useAdInit } from "@/hooks/useAdInit";
 import { useGtm } from "@/hooks/useGtm";
 import { SITE_URL } from "@/config/site";
+import { AppHeader } from "@/components/ui/AppHeader";
 import "@/i18n";
 
 const STRUCTURED_DATA = JSON.stringify({
@@ -53,17 +54,19 @@ export default function RootLayout() {
       )}
       <Stack
         screenOptions={{
-          headerStyle: { backgroundColor: colors.background },
-          headerTintColor: colors.text,
-          headerTitleStyle: { fontWeight: "700" },
           contentStyle: { backgroundColor: colors.background },
+          header: ({ navigation, options, back }) => (
+            <AppHeader
+              sectionTitle={
+                typeof options.title === "string" ? options.title : undefined
+              }
+              onBack={back ? () => navigation.goBack() : undefined}
+            />
+          ),
         }}
       >
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-        <Stack.Screen
-          name="character/[slug]"
-          options={{ headerBackTitle: "" }}
-        />
+        <Stack.Screen name="character/[slug]" />
       </Stack>
     </>
   );

--- a/src/app/character/[slug].tsx
+++ b/src/app/character/[slug].tsx
@@ -57,11 +57,6 @@ export default function CharacterDetailScreen() {
         description={`Complete ${data.name} frame data for Street Fighter 6. All normals, specials, supers with startup, active, recovery, block advantage, and hit advantage frames.`}
         path={`/character/${slug}`}
       />
-      <View style={styles.versionRow}>
-        <Text style={styles.versionText}>
-          {t("settings.version", { version: data.version })}
-        </Text>
-      </View>
 
       <View style={styles.filterRow}>
         <ScrollView
@@ -127,14 +122,6 @@ const styles = StyleSheet.create({
   },
   loadingText: {
     color: colors.textMuted,
-  },
-  versionRow: {
-    paddingHorizontal: 16,
-    paddingVertical: 8,
-  },
-  versionText: {
-    color: colors.textMuted,
-    fontSize: 11,
   },
   filterRow: {
     paddingHorizontal: 16,

--- a/src/components/ui/AppHeader.tsx
+++ b/src/components/ui/AppHeader.tsx
@@ -1,0 +1,100 @@
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTranslation } from "react-i18next";
+import { Ionicons } from "@expo/vector-icons";
+import { colors } from "@/theme/colors";
+import { useDataStore } from "@/stores/useDataStore";
+
+interface AppHeaderProps {
+  /** 現在の画面名（タブ名やページタイトル） */
+  sectionTitle?: string;
+  /** 戻るボタンを表示する際に呼び出される */
+  onBack?: () => void;
+}
+
+/**
+ * アプリ共通ヘッダー。
+ * - サイト名（SF6 Frame Data）を常に表示し、ランディング時にサイトが分かるようにする
+ * - 現在のセクション名を副題として表示
+ * - データバージョンを右側に表示
+ */
+export function AppHeader({ sectionTitle, onBack }: AppHeaderProps) {
+  const insets = useSafeAreaInsets();
+  const { t } = useTranslation();
+  const version = useDataStore((s) => s.version?.version);
+
+  return (
+    <View style={[styles.container, { paddingTop: insets.top + 8 }]}>
+      <View style={styles.row}>
+        {onBack ? (
+          <Pressable
+            onPress={onBack}
+            style={styles.backButton}
+            accessibilityRole="button"
+            accessibilityLabel={t("common.cancel")}
+            hitSlop={8}
+          >
+            <Ionicons name="chevron-back" size={22} color={colors.accent} />
+          </Pressable>
+        ) : null}
+        <View style={styles.titleColumn}>
+          <Text style={styles.brand} numberOfLines={1}>
+            SF6 Frame Data
+          </Text>
+          {sectionTitle ? (
+            <Text style={styles.section} numberOfLines={1}>
+              {sectionTitle}
+            </Text>
+          ) : null}
+        </View>
+        {version ? (
+          <Text style={styles.version} numberOfLines={1}>
+            {t("settings.version", { version })}
+          </Text>
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: colors.background,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+    paddingHorizontal: 16,
+    paddingBottom: 10,
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "flex-end",
+    justifyContent: "space-between",
+    gap: 8,
+  },
+  backButton: {
+    marginRight: 4,
+    marginBottom: 2,
+    paddingVertical: 2,
+  },
+  titleColumn: {
+    flex: 1,
+    minWidth: 0,
+  },
+  brand: {
+    color: colors.text,
+    fontSize: 16,
+    fontWeight: "700",
+    letterSpacing: 0.2,
+  },
+  section: {
+    color: colors.accent,
+    fontSize: 12,
+    fontWeight: "600",
+    marginTop: 2,
+  },
+  version: {
+    color: colors.textMuted,
+    fontSize: 10,
+    fontVariant: ["tabular-nums"],
+  },
+});

--- a/src/components/ui/WebContainer.tsx
+++ b/src/components/ui/WebContainer.tsx
@@ -12,7 +12,8 @@ export function WebContainer({ children, style }: WebContainerProps) {
   const { containerMaxWidth, isWide } = useResponsive();
 
   if (!isWide) {
-    return <View style={[styles.root, style]}>{children}</View>;
+    // モバイル: 画面幅いっぱいに表示し、横方向のはみ出しを防ぐ
+    return <View style={[styles.rootMobile, style]}>{children}</View>;
   }
 
   return (
@@ -29,10 +30,18 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: colors.background,
     alignItems: "center",
+    overflow: "hidden",
+  },
+  rootMobile: {
+    flex: 1,
+    backgroundColor: colors.background,
+    width: "100%",
+    overflow: "hidden",
   },
   inner: {
     flex: 1,
     width: "100%",
     backgroundColor: colors.background,
+    overflow: "hidden",
   },
 });

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -87,8 +87,7 @@
     "title": "Support the Developer",
     "description": "If you enjoy this app, please consider supporting development",
     "github": "GitHub Sponsors",
-    "buymeacoffee": "Buy Me a Coffee",
-    "githubRepo": "Source Code (GitHub)"
+    "buymeacoffee": "Buy Me a Coffee"
   },
   "credits": {
     "title": "Credits & Licenses",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -87,8 +87,7 @@
     "title": "開発者を支援",
     "description": "このアプリを気に入っていただけたら、開発支援をお願いします",
     "github": "GitHub Sponsors",
-    "buymeacoffee": "Buy Me a Coffee",
-    "githubRepo": "ソースコード（GitHub）"
+    "buymeacoffee": "Buy Me a Coffee"
   },
   "credits": {
     "title": "クレジット・ライセンス",


### PR DESCRIPTION
- WebContainer の alignItems:center がモバイルで子要素を中央寄せし、
  コンテンツが画面幅を超えて横にはみ出す原因になっていたため、
  モバイルでは全幅ストレッチ（overflow:hidden 付き）に変更
- AppHeader を新設し、タブ/スタック共通のヘッダーとして
  サイト名（SF6 Frame Data）・現在のセクション名・データバージョンを
  常に表示。ランディング時にサイト・データ鮮度が一目で分かるようにした
- キャラ詳細ページのバージョン行は AppHeader と重複するため削除