### PR TITLE
feat(analytics): GTM を有効化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,8 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm build:web
+        env:
+          EXPO_PUBLIC_GTM_ID: GTM-P9VNNCTQ
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- CI の `build-web` ジョブに `EXPO_PUBLIC_GTM_ID=GTM-P9VNNCTQ` を追加
- `useGtm()` フックは既に `_layout.tsx` で呼ばれているが、環境変数未設定のため無効化されていた
- これにより Web 版で Google Tag Manager によるアクセス解析が有効になる

## Test plan
- [ ] マージ後のデプロイで sf6-frame.app にアクセスし、GTM のリアルタイムレポートでイベントが記録されることを確認
- [ ] ブラウザの DevTools Network タブで `gtm.js` がロードされていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)